### PR TITLE
Remove fluent assertions

### DIFF
--- a/MyWhiskyShelf.Database.Tests/MyWhiskyShelf.Database.Tests.csproj
+++ b/MyWhiskyShelf.Database.Tests/MyWhiskyShelf.Database.Tests.csproj
@@ -9,7 +9,6 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="FluentAssertions" Version="8.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>

--- a/MyWhiskyShelf.IntegrationTests/MyWhiskyShelf.IntegrationTests.csproj
+++ b/MyWhiskyShelf.IntegrationTests/MyWhiskyShelf.IntegrationTests.csproj
@@ -11,7 +11,6 @@
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.Testing" Version="9.3.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="FluentAssertions" Version="8.3.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>

--- a/MyWhiskyShelf.IntegrationTests/StatusTests/ServiceStatusTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/StatusTests/ServiceStatusTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using MyWhiskyShelf.IntegrationTests.Fixtures;
 
 namespace MyWhiskyShelf.IntegrationTests.StatusTests;
@@ -14,9 +13,9 @@ public class ServiceStatusTests(MyWhiskyShelfFixture myWhiskyShelfFixture) : ICl
         
         var response = await httpClient.GetAsync(endpointName);
         var body = await response.Content.ReadAsStringAsync();
-        
+
         Assert.Multiple(
-            () => response.StatusCode.Should().Be(HttpStatusCode.OK),
-            () => body.Should().Be("Healthy"));
+            () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
+            () => Assert.Equal("Healthy", body));
     }
 }

--- a/MyWhiskyShelf.IntegrationTests/StatusTests/ServiceStatusTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/StatusTests/ServiceStatusTests.cs
@@ -6,7 +6,7 @@ public class ServiceStatusTests(MyWhiskyShelfFixture myWhiskyShelfFixture) : ICl
 {
     [Theory]
     [InlineData("WebApi")]
-    public async Task ResourceHealthEndpointReturnsHealthyWhenResourceIsRunning(string resourceName)
+    public async Task When_ResourceIsRunning_Expect_ResourceHealthEndpointReturnsHealthy(string resourceName)
     {
         const string endpointName = "/health";
         using var httpClient = myWhiskyShelfFixture.Application.CreateHttpClient(resourceName);


### PR DESCRIPTION
* Due to licence changes for `FluentAssertions` this will be removed.
* Update integration tests to use standard `xUnit` assertions.