### PR TITLE
Refactor MyWhiskyShelfDbContext

### DIFF
--- a/MyWhiskyShelf.Database.Tests/Services/DistilleryReadServiceTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Services/DistilleryReadServiceTests.cs
@@ -1,21 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using MyWhiskyShelf.Database.Contexts;
 using MyWhiskyShelf.Database.Models;
+using MyWhiskyShelf.Database.Services;
 using MyWhiskyShelf.Models;
 
-namespace MyWhiskyShelf.Database.Tests.Contexts;
+namespace MyWhiskyShelf.Database.Tests.Services;
 
-public class MyWhiskyShelfDbContextTests
+public class DistilleryReadServiceTests
 {
     [Fact]
     public async Task When_GetAllDistilleriesAndNoDistilleriesAreFound_Expect_EmptyList()
     {
-        var options = new DbContextOptionsBuilder<MyWhiskyShelfDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-        
-        await using var dbContext = new MyWhiskyShelfDbContext(options);
-        var distilleries = await dbContext.GetAllDistilleriesAsync();
+        await using var dbContext = CreateDbContext; 
+        var distilleryReadService = new DistilleryReadService(dbContext);
+        var distilleries = await distilleryReadService.GetAllDistilleriesAsync();
         
         Assert.Empty(distilleries);
     }
@@ -47,11 +45,7 @@ public class MyWhiskyShelfDbContextTests
             }
         }; 
         
-        var options = new DbContextOptionsBuilder<MyWhiskyShelfDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-        
-        await using var dbContext = new MyWhiskyShelfDbContext(options);
+        await using var dbContext = CreateDbContext; 
         await dbContext.Set<DistilleryEntity>().AddRangeAsync(
             new DistilleryEntity 
             { 
@@ -74,9 +68,17 @@ public class MyWhiskyShelfDbContextTests
                 Active = false
             });
         await dbContext.SaveChangesAsync();
+
         
-        var distilleries = await dbContext.GetAllDistilleriesAsync();
+        var distilleryReadService = new DistilleryReadService(dbContext);
+        var distilleries = await distilleryReadService.GetAllDistilleriesAsync();
         
         Assert.Equal(expectedDistilleries.Count, distilleries.Count);
     }
+    
+    private static MyWhiskyShelfDbContext CreateDbContext => new(
+        new DbContextOptionsBuilder<MyWhiskyShelfDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options);
+
 }

--- a/MyWhiskyShelf.Database/Contexts/MyWhiskyShelfDbContext.cs
+++ b/MyWhiskyShelf.Database/Contexts/MyWhiskyShelfDbContext.cs
@@ -1,16 +1,11 @@
 using Microsoft.EntityFrameworkCore;
-using MyWhiskyShelf.Database.Extensions;
 using MyWhiskyShelf.Database.Models;
-using MyWhiskyShelf.Models;
 
 namespace MyWhiskyShelf.Database.Contexts;
 
 public class MyWhiskyShelfDbContext(DbContextOptions<MyWhiskyShelfDbContext> options) : DbContext(options)
 {
-    private DbSet<DistilleryEntity> Distilleries { get; set; }
+    internal DbSet<DistilleryEntity> Distilleries { get; set; }
 
-    public async Task<List<Distillery>> GetAllDistilleriesAsync()
-        => await Distilleries
-            .Select(distilleryEntity => distilleryEntity.ProjectToDistillery())
-            .ToListAsync();
+   
 }

--- a/MyWhiskyShelf.Database/Extensions/HostApplicationBuilderExtensions.cs
+++ b/MyWhiskyShelf.Database/Extensions/HostApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MyWhiskyShelf.Database.Contexts;
+using MyWhiskyShelf.Database.Services;
 
 namespace MyWhiskyShelf.Database.Extensions;
 
@@ -15,7 +16,6 @@ public static class HostApplicationBuilderExtensions
         builder.Services.AddDbContext<MyWhiskyShelfDbContext>(options => 
             options.UseNpgsql(builder.Configuration.GetConnectionString("postgresDb") 
                               ?? throw new InvalidOperationException("Connection string not found")));
-
         builder.EnrichNpgsqlDbContext<MyWhiskyShelfDbContext>(settings =>
         {
             settings.DisableRetry = false;
@@ -24,6 +24,8 @@ public static class HostApplicationBuilderExtensions
             settings.DisableMetrics = false;
             settings.DisableTracing = false;
         });
+        
+        builder.Services.AddScoped<DistilleryReadService>();
         
         return builder;
     }

--- a/MyWhiskyShelf.Database/Services/DistilleryReadService.cs
+++ b/MyWhiskyShelf.Database/Services/DistilleryReadService.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using MyWhiskyShelf.Database.Contexts;
+using MyWhiskyShelf.Database.Extensions;
+using MyWhiskyShelf.Models;
+
+namespace MyWhiskyShelf.Database.Services;
+
+public class DistilleryReadService(MyWhiskyShelfDbContext dbContext)
+{
+    public async Task<List<Distillery>> GetAllDistilleriesAsync()
+        => await dbContext.Distilleries
+            .Select(distilleryEntity => distilleryEntity.ProjectToDistillery())
+            .ToListAsync();
+}


### PR DESCRIPTION
* Refactor to ensure that the `DbContext` stays focused on entities and EF mechanics.
* `DistilleryReadService` added to handle units of work against the `DbContext`.
* Copy across test to run against the service instead of the context.