### PR TITLE
Refactor Integration tests for test isolation

### DIFF
--- a/MyWhiskyShelf.Database.Tests/Services/DistilleryReadServiceTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Services/DistilleryReadServiceTests.cs
@@ -66,7 +66,7 @@ public class DistilleryReadServiceTests
 
         Assert.All(expectedDistilleryResponses, distillery => Assert.Contains(distillery, distilleries));
     }
-    
+
     [Fact]
     public async Task When_GetDistilleryByIdAndDistilleryIsNotFound_Expect_NoDistilleryReturned()
     {

--- a/MyWhiskyShelf.Database.Tests/Services/DistilleryWriteServiceTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Services/DistilleryWriteServiceTests.cs
@@ -23,14 +23,14 @@ public class DistilleryWriteServiceTests
             dbContext,
             new Mock<IDistilleryNameCacheService>().Object,
             new DistilleryRequestToEntityMapper());
-        var result = await distilleryWriteService
+        var (hasBeenAdded, _) = await distilleryWriteService
             .TryAddDistilleryAsync(DistilleryRequestTestData.Aberargie);
         var distilleryEntity = await dbContext
             .Set<DistilleryEntity>()
             .FirstAsync(entity => entity.DistilleryName == DistilleryEntityTestData.Aberargie.DistilleryName);
 
         Assert.Multiple(
-            () => Assert.True(result, "'result' should be true"),
+            () => Assert.True(hasBeenAdded, "'hasBeenAdded' should be true"),
             () => Assert.Equal(
                 DistilleryEntityTestData.Aberargie with { Id = distilleryEntity.Id },
                 distilleryEntity));
@@ -54,14 +54,14 @@ public class DistilleryWriteServiceTests
             dbContext,
             mockDistilleryNameCacheService.Object,
             new DistilleryRequestToEntityMapper());
-        var result = await distilleryWriteService.TryAddDistilleryAsync(modifiedAberargieDistillery);
+        var (hasBeenAdded, _) = await distilleryWriteService.TryAddDistilleryAsync(modifiedAberargieDistillery);
 
         var distilleryEntity = await dbContext
             .Set<DistilleryEntity>()
             .FirstAsync(entity => entity.DistilleryName == modifiedAberargieDistillery.DistilleryName);
 
         Assert.Multiple(
-            () => Assert.False(result, "'result' should be false"),
+            () => Assert.False(hasBeenAdded, "'hasBeenAdded' should be false"),
             () => Assert.Equal(distilleryEntity, DistilleryEntityTestData.Aberargie));
     }
 
@@ -123,7 +123,7 @@ public class DistilleryWriteServiceTests
             dbContext,
             mockDistilleryNameCacheService.Object,
             new DistilleryRequestToEntityMapper());
-        await distilleryWriteService.TryRemoveDistilleryAsync(DistilleryRequestTestData.Aberargie.DistilleryName);
+        await distilleryWriteService.TryRemoveDistilleryAsync(DistilleryEntityTestData.Aberargie.Id);
 
         var distilleryEntity = await dbContext
             .Set<DistilleryEntity>()
@@ -147,7 +147,7 @@ public class DistilleryWriteServiceTests
             dbContext,
             mockDistilleryNameCacheService.Object,
             new DistilleryRequestToEntityMapper());
-        await distilleryWriteService.TryRemoveDistilleryAsync(DistilleryRequestTestData.Aberargie.DistilleryName);
+        await distilleryWriteService.TryRemoveDistilleryAsync(DistilleryEntityTestData.Aberargie.Id);
 
         mockDistilleryNameCacheService.Verify();
     }

--- a/MyWhiskyShelf.Database/Interfaces/IDistilleryWriteService.cs
+++ b/MyWhiskyShelf.Database/Interfaces/IDistilleryWriteService.cs
@@ -4,6 +4,6 @@ namespace MyWhiskyShelf.Database.Interfaces;
 
 public interface IDistilleryWriteService
 {
-    Task<bool> TryAddDistilleryAsync(DistilleryRequest distilleryRequest);
-    Task<bool> TryRemoveDistilleryAsync(string distilleryName);
+    Task<(bool hasBeenAdded, Guid? identifier)> TryAddDistilleryAsync(DistilleryRequest distilleryRequest);
+    Task<bool> TryRemoveDistilleryAsync(Guid distilleryId);
 }

--- a/MyWhiskyShelf.Database/Services/DistilleryNameCacheService.cs
+++ b/MyWhiskyShelf.Database/Services/DistilleryNameCacheService.cs
@@ -28,7 +28,7 @@ public class DistilleryNameCacheService : IDistilleryNameCacheService
         var distilleryNameDetailsDictionary = new ConcurrentDictionary<string, DistilleryNameDetails>(
             distilleryDetails.ToDictionary(details => details.DistilleryName, details => details),
             StringComparer.OrdinalIgnoreCase);
-        
+
         var distilleryIdDictionary = new ConcurrentDictionary<Guid, string>(
             distilleryDetails.ToDictionary(details => details.Identifier, details => details.DistilleryName));
 

--- a/MyWhiskyShelf.Database/Services/DistilleryReadService.cs
+++ b/MyWhiskyShelf.Database/Services/DistilleryReadService.cs
@@ -10,7 +10,6 @@ public class DistilleryReadService(
     MyWhiskyShelfDbContext dbContext,
     IMapper<DistilleryEntity, DistilleryResponse> mapper) : IDistilleryReadService
 {
-    
     public async Task<DistilleryResponse?> GetDistilleryByIdAsync(Guid distilleryId)
     {
         var distillery = await dbContext.Distilleries.FindAsync(distilleryId);
@@ -19,7 +18,7 @@ public class DistilleryReadService(
             ? null
             : mapper.Map(distillery);
     }
-    
+
     public async Task<IReadOnlyList<DistilleryResponse>> GetAllDistilleriesAsync()
     {
         var distilleryEntities = await dbContext.Distilleries

--- a/MyWhiskyShelf.IntegrationTests/Collections/AspireTestCollection.cs
+++ b/MyWhiskyShelf.IntegrationTests/Collections/AspireTestCollection.cs
@@ -1,4 +1,6 @@
+using MyWhiskyShelf.IntegrationTests.Fixtures;
+
 namespace MyWhiskyShelf.IntegrationTests.Collections;
 
-[CollectionDefinition("AspireTests", DisableParallelization = true)]
-public class AspireTestCollection;
+[CollectionDefinition("AspireTests")]
+public class AspireTestCollection : ICollectionFixture<MyWhiskyShelfFixture>;

--- a/MyWhiskyShelf.IntegrationTests/Fixtures/MyWhiskyShelfFixture.cs
+++ b/MyWhiskyShelf.IntegrationTests/Fixtures/MyWhiskyShelfFixture.cs
@@ -8,8 +8,6 @@ namespace MyWhiskyShelf.IntegrationTests.Fixtures;
 [UsedImplicitly]
 public class MyWhiskyShelfFixture : IAsyncLifetime
 {
-    protected virtual bool UseDataSeeding => true;
-    
     public DistributedApplication Application { get; private set; } = null!;
 
     public virtual async Task InitializeAsync()
@@ -17,7 +15,7 @@ public class MyWhiskyShelfFixture : IAsyncLifetime
         var appHost = await CreateDefaultAppHost();
         Application = await appHost.BuildAsync();
         Application.Start();
-        
+
         await WaitForRunningState(Application, "WebApi");
     }
 
@@ -26,10 +24,10 @@ public class MyWhiskyShelfFixture : IAsyncLifetime
         await Application.DisposeAsync();
     }
 
-    private async Task<IDistributedApplicationTestingBuilder> CreateDefaultAppHost()
+    private static async Task<IDistributedApplicationTestingBuilder> CreateDefaultAppHost()
     {
         var appHost = await DistributedApplicationTestingBuilder.CreateAsync<MyWhiskyShelf_AppHost>(
-            [$"MYWHISKYSHELF_DATA_SEEDING_ENABLED={UseDataSeeding}"]);
+            ["MYWHISKYSHELF_DATA_SEEDING_ENABLED=false"]);
 
         appHost.Services
             .ConfigureHttpClientDefaults(clientBuilder => clientBuilder.AddStandardResilienceHandler());

--- a/MyWhiskyShelf.IntegrationTests/Status/ServiceStatusTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/Status/ServiceStatusTests.cs
@@ -2,8 +2,8 @@ using MyWhiskyShelf.IntegrationTests.Fixtures;
 
 namespace MyWhiskyShelf.IntegrationTests.Status;
 
+[Collection("AspireTests")]
 public class ServiceStatusTests(MyWhiskyShelfFixture fixture)
-    : IClassFixture<MyWhiskyShelfFixture>
 {
     [Theory]
     [InlineData("WebApi")]

--- a/MyWhiskyShelf.IntegrationTests/WebApi/WebApiDistilleriesTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/WebApi/WebApiDistilleriesTests.cs
@@ -3,140 +3,117 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MyWhiskyShelf.Core.Models;
 using MyWhiskyShelf.IntegrationTests.Fixtures;
+using MyWhiskyShelf.TestHelpers;
 using MyWhiskyShelf.TestHelpers.Data;
 
 namespace MyWhiskyShelf.IntegrationTests.WebApi;
 
-public static class WebApiDistilleriesTests
+[Collection("AspireTests")]
+public class WebApiDistilleriesTests(MyWhiskyShelfFixture fixture)
 {
     private const string WebApiResourceName = "WebApi";
 
-    private static bool EqualsIgnoringId(DistilleryResponse expected, DistilleryResponse actual)
+    [Fact]
+    public async Task When_RequestingAllDistilleries_Expect_AllDistilleriesReturned()
     {
-        return expected with { Id = Guid.Empty } == actual with { Id = Guid.Empty };
+        const string endpoint = "/distilleries";
+        List<DistilleryResponse> expectedDistilleryResponses =
+        [
+            DistilleryResponseTestData.Aberargie,
+            DistilleryResponseTestData.Aberfeldy,
+            DistilleryResponseTestData.Aberlour
+        ];
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var addedIds = await DatabaseSeeding.AddDistilleries(
+            httpClient,
+            DistilleryRequestTestData.Aberargie,
+            DistilleryRequestTestData.Aberfeldy,
+            DistilleryRequestTestData.Aberlour);
+
+        var response = await httpClient.GetAsync(endpoint);
+        var distilleries = await response.Content.ReadFromJsonAsync<List<DistilleryResponse>>();
+        await DatabaseSeeding.RemoveDistilleries(httpClient, addedIds);
+
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
+            () => Assert.All(expectedDistilleryResponses, distillery
+                => Assert.Contains(distilleries!, actual => Assertions.EqualsIgnoringId(distillery, actual))),
+            () => Assert.All(distilleries!, distillery
+                => Assert.NotEqual(Guid.Empty, distillery.Id)));
     }
 
-    [Collection("AspireTests")]
-    public class WebApiSeededDataTests(MyWhiskyShelfFixture fixture)
-        : IClassFixture<MyWhiskyShelfFixture>
+    [Fact]
+    public async Task When_RequestingDistilleryByIdAndDistilleryExists_Expect_CorrectDistilleryReturned()
     {
-        [Fact]
-        public async Task When_RequestingAllDistilleries_Expect_AllDistilleriesReturned()
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var addedIds = await DatabaseSeeding.AddDistilleries(httpClient, DistilleryRequestTestData.Aberargie);
+        var distilleryEndpoint = $"/distilleries/{addedIds.First()}";
+
+        var distilleryResponse = await httpClient.GetAsync(distilleryEndpoint);
+        var distillery = await distilleryResponse.Content.ReadFromJsonAsync<DistilleryResponse>();
+        await DatabaseSeeding.RemoveDistilleries(httpClient, addedIds);
+
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.OK, distilleryResponse.StatusCode),
+            () => Assert.True(Assertions.EqualsIgnoringId(DistilleryResponseTestData.Aberargie, distillery!)));
+    }
+
+    [Fact]
+    public async Task When_RequestingDistilleryByIdAndDistilleryDoesNotExist_Expect_NotFoundResponse()
+    {
+        var endpoint = $"/distilleries/{Guid.NewGuid()}";
+
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var response = await httpClient.GetAsync(endpoint);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task When_AddingDistilleryAndDistilleryDoesNotExist_Expect_CreatedWithLocationHeaderSet()
+    {
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var response = await httpClient.PostAsJsonAsync(
+            "/distilleries",
+            DistilleryRequestTestData.Aberargie);
+
+        Assert.Multiple(
+            () => Assert.NotNull(response.Headers.Location),
+            () => Assert.Equal(HttpStatusCode.Created, response.StatusCode));
+
+        await httpClient.DeleteAsync(response.Headers.Location!.OriginalString);
+    }
+
+    [Fact]
+    public async Task When_RemovingDistilleryAndDistilleryExists_Expect_OkResponse()
+    {
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var distilleryIds = await DatabaseSeeding.AddDistilleries(httpClient, DistilleryRequestTestData.Aberfeldy);
+
+        var response = await httpClient.DeleteAsync($"/distilleries/{distilleryIds.First()}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task When_RemovingDistilleryAndDistilleryDoesNotExist_Expect_NotFoundProblemResponse()
+    {
+        var id = Guid.NewGuid();
+        var expectedProblem = new ProblemDetails
         {
-            const string endpoint = "/distilleries";
-            List<DistilleryResponse> expectedDistilleries =
-            [
-                DistilleryResponseTestData.Aberargie,
-                DistilleryResponseTestData.Aberfeldy,
-                DistilleryResponseTestData.Aberlour
-            ];
+            Type = "urn:mywhiskyshelf:errors:distillery-does-not-exist",
+            Title = "Distillery does not exist.",
+            Status = StatusCodes.Status404NotFound,
+            Detail = $"Cannot remove distillery '{id}' as it does not exist.",
+            Instance = $"/distilleries/{id}"
+        };
 
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-            var distilleries = await response.Content.ReadFromJsonAsync<List<DistilleryResponse>>();
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var response = await httpClient.DeleteAsync($"/distilleries/{id}");
+        var problemResponse = await response.Content.ReadFromJsonAsync<ProblemDetails>();
 
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
-                () => Assert.All(expectedDistilleries, distillery
-                    => Assert.Contains(distilleries!, actual => EqualsIgnoringId(distillery, actual))),
-                () => Assert.All(distilleries!, distillery
-                    => Assert.NotEqual(Guid.Empty, distillery.Id)));
-        }
-
-        [Fact]
-        public async Task When_RequestingDistilleryByIdAndDistilleryExists_Expect_CorrectDistilleryReturned()
-        {
-            const string detailsEndpoint = "/distilleries/name/search?pattern=Aberfeldy";
-            
-            // get the ID of an existing distillery.
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var detailsResponse = await httpClient.GetAsync(detailsEndpoint);
-            var distilleryDetails = await detailsResponse.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
-            
-            var distilleryEndpoint = $"/distilleries/{distilleryDetails!.First().Identifier}";
-            
-            var distilleryResponse = await httpClient.GetAsync(distilleryEndpoint);
-            var distillery = await distilleryResponse.Content.ReadFromJsonAsync<DistilleryResponse>();
-
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.OK, distilleryResponse.StatusCode),
-                () => Assert.True(EqualsIgnoringId(DistilleryResponseTestData.Aberfeldy, distillery!)));
-        }
-
-        [Fact]
-        public async Task When_RequestingDistilleryByIdAndDistilleryDoesNotExist_Expect_NotFoundResponse()
-        {
-            var endpoint = $"/distilleries/{Guid.NewGuid()}";
-
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task When_AddingDistilleryAndDistilleryDoesNotExist_Expect_CreatedWithLocationHeaderSet()
-        {
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.PostAsJsonAsync(
-                "/distilleries",
-                DistilleryRequestTestData.Aberargie with { DistilleryName = "NewDistillery" });
-            await httpClient.DeleteAsync("/distilleries/remove/NewDistillery");
-
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal("/distilleries/NewDistillery", response.Headers.Location!.ToString());
-        }
-
-        [Fact]
-        public async Task When_RemovingDistilleryAndDistilleryExists_Expect_OkResponse()
-        {
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            
-            await httpClient.PostAsJsonAsync(
-                "/distilleries",
-                DistilleryRequestTestData.Aberargie with { DistilleryName = "NewDistilleryToRemove" });
-            
-            var response = await httpClient.DeleteAsync("/distilleries/remove/NewDistilleryToRemove");
-            
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task When_RemovingDistilleryAndDistilleryDoesNotExist_Expect_NotFoundProblemResponse()
-        {
-            var expectedProblem = new ProblemDetails
-            {
-                Type = "urn:mywhiskyshelf:errors:distillery-does-not-exist",
-                Title = "Distillery does not exist.",
-                Status = StatusCodes.Status404NotFound,
-                Detail = "Cannot remove distillery 'FakeDistillery' as it does not exist.",
-                Instance = "/distilleries/remove/FakeDistillery"
-            };
-
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.DeleteAsync("/distilleries/remove/FakeDistillery");
-            var problemResponse = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.NotFound, response.StatusCode),
-                () => Assert.Equivalent(expectedProblem, problemResponse));
-        }
-
-        [Fact]
-        public async Task
-            When_AddingDistilleryAndNameContainsSpecialCharacters_Expect_CreatedWithUrlEncodedLocationHeaderSet()
-        {
-            const string endpoint = "/distilleries";
-
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.PostAsJsonAsync(
-                endpoint,
-                DistilleryRequestTestData.Aberargie with { DistilleryName = "Burn O'Bennie" });
-
-            await httpClient.DeleteAsync("/distilleries/remove/Burn%20O%27Bennie");
-
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal("/distilleries/Burn%20O%27Bennie", response.Headers.Location!.ToString());
-        }
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.NotFound, response.StatusCode),
+            () => Assert.Equivalent(expectedProblem, problemResponse));
     }
 }

--- a/MyWhiskyShelf.IntegrationTests/WebApi/WebApiDistilleryNameTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/WebApi/WebApiDistilleryNameTests.cs
@@ -3,128 +3,167 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MyWhiskyShelf.Core.Models;
 using MyWhiskyShelf.IntegrationTests.Fixtures;
+using MyWhiskyShelf.TestHelpers;
 using MyWhiskyShelf.TestHelpers.Data;
 
 namespace MyWhiskyShelf.IntegrationTests.WebApi;
 
-public static class WebApiDistilleryNameTests
+[Collection("AspireTests")]
+public class WebApiDistilleryNameTests(MyWhiskyShelfFixture fixture)
 {
     private const string WebApiResourceName = "WebApi";
 
-    [Collection("AspireTests")]
-    public class WebApiSeededDataTests(MyWhiskyShelfFixture fixture)
-        : IClassFixture<MyWhiskyShelfFixture>
+    [Fact]
+    public async Task When_GettingAllDistilleryNamesDetails_Expect_AllDistilleriesNameDetailsToBeReturned()
     {
-        [Fact]
-        public async Task When_GettingAllDistilleryNamesDetails_Expect_AllDistilleriesNameDetailsToBeReturned()
-        {
-            const string endpoint = "/distilleries/names";
-            List<string> expectedDistilleryNames =
-            [
-                DistilleryResponseTestData.Aberargie.DistilleryName,
-                DistilleryResponseTestData.Aberfeldy.DistilleryName,
-                DistilleryResponseTestData.Aberlour.DistilleryName
-            ];
+        const string endpoint = "/distilleries/names";
 
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-            var distilleryNames = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
+        List<string> expectedDistilleryNames =
+        [
+            DistilleryResponseTestData.Aberargie.DistilleryName,
+            DistilleryResponseTestData.Aberfeldy.DistilleryName,
+            DistilleryResponseTestData.Aberlour.DistilleryName
+        ];
 
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
-                () => Assert.All(distilleryNames!, details =>
-                {
-                    var (distilleryName, identifier) = details;
-                    Assert.Contains(distilleryName, expectedDistilleryNames);
-                    Assert.NotEqual(Guid.Empty, identifier);
-                }));
-        }
-        
-        [Fact]
-        public async Task When_SearchingByNameAndNoMatchesFound_Expect_EmptyList()
-        {
-            const string endpoint = "/distilleries/name/search?pattern=anything";
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var addedIds = await SeedTestData(httpClient);
 
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-            var distilleryNames = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
+        var response = await httpClient.GetAsync(endpoint);
+        var distilleryNames = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
+        await DatabaseSeeding.RemoveDistilleries(httpClient, addedIds);
 
-
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
-                () => Assert.Empty(distilleryNames!));
-        }
-
-        [Fact]
-        public async Task When_SearchingByNameAndMatchesExactly_Expect_ListWithJustThoseDistilleryNameDetails()
-        {
-            var endpoint = $"/distilleries/name/search?pattern={DistilleryRequestTestData.Aberfeldy.DistilleryName}";
-
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-            var distilleryNameDetails = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
-
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
-                () => Assert.Single(distilleryNameDetails!),
-                () => Assert.Equal(DistilleryRequestTestData.Aberfeldy.DistilleryName,
-                    distilleryNameDetails!.First().DistilleryName),
-                () => Assert.IsType<Guid>(distilleryNameDetails!.First().Identifier));
-        }
-
-        [Fact]
-        public async Task When_SearchingByNameAndPatternIsNotProvided_Expect_BadRequestWithValidationProblemDetails()
-        {
-            const string endpoint = "/distilleries/name/search";
-
-            var expectedProblem = new ValidationProblemDetails
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
+            () => Assert.All(distilleryNames!, details =>
             {
-                Status = StatusCodes.Status400BadRequest,
-                Title = "Missing or empty query parameters",
-                Type = "urn:mywhiskyshelf:validation-errors:query-parameter",
-                Errors = new Dictionary<string, string[]>
-                {
-                    { "pattern", ["Query parameter 'pattern' is required and cannot be empty."] }
-                }
-            };
+                var (distilleryName, identifier) = details;
+                Assert.Contains(distilleryName, expectedDistilleryNames);
+                Assert.NotEqual(Guid.Empty, identifier);
+            }));
+    }
 
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-            var problemResponse = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+    private static async Task<List<Guid>> SeedTestData(HttpClient httpClient)
+    {
+        var addedIds = await DatabaseSeeding.AddDistilleries(
+            httpClient,
+            DistilleryRequestTestData.Aberargie,
+            DistilleryRequestTestData.Aberfeldy,
+            DistilleryRequestTestData.Aberlour);
+        return addedIds;
+    }
 
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode),
-                () => Assert.Equivalent(expectedProblem, problemResponse));
-        }
+    [Fact]
+    public async Task When_SearchingByNameAndNoMatchesFound_Expect_EmptyList()
+    {
+        const string endpoint = "/distilleries/name/search?pattern=anything";
 
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("   ")]
-        [InlineData("    ")]
-        [InlineData("\t \n")]
-        public async Task When_SearchingByNameAndPatternIsEmptyOrWhiteSpace_Expect_BadRequestProblemResponse(
-            string pattern)
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var response = await httpClient.GetAsync(endpoint);
+        var distilleryNames = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
+
+
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
+            () => Assert.Empty(distilleryNames!));
+    }
+
+    [Fact]
+    public async Task When_SearchingByNameAndMatchesExactly_Expect_ListWithJustThoseDistilleryNameDetails()
+    {
+        var endpoint = $"/distilleries/name/search?pattern={DistilleryRequestTestData.Aberfeldy.DistilleryName}";
+
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var addedIds = await SeedTestData(httpClient);
+
+        var response = await httpClient.GetAsync(endpoint);
+        var distilleryNameDetails = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
+        await DatabaseSeeding.RemoveDistilleries(httpClient, addedIds);
+
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
+            () => Assert.Single(distilleryNameDetails!),
+            () => Assert.Equal(DistilleryRequestTestData.Aberfeldy.DistilleryName,
+                distilleryNameDetails!.First().DistilleryName),
+            () => Assert.IsType<Guid>(distilleryNameDetails!.First().Identifier));
+    }
+
+    [Fact]
+    public async Task When_SearchingByNameAndFuzzyMatches_Expect_ListWithJustThoseFuzzyMatchedNameDetails()
+    {
+        const string endpoint = "/distilleries/name/search?pattern=erl";
+        List<string> expectedDistilleryNames =
+        [
+            DistilleryResponseTestData.Aberfeldy.DistilleryName,
+            DistilleryResponseTestData.Aberlour.DistilleryName
+        ];
+
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var addedIds = await SeedTestData(httpClient);
+
+        var response = await httpClient.GetAsync(endpoint);
+        var distilleryNameDetails = await response.Content.ReadFromJsonAsync<List<DistilleryNameDetails>>();
+        await DatabaseSeeding.RemoveDistilleries(httpClient, addedIds);
+
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.OK, response.StatusCode),
+            () => Assert.All(expectedDistilleryNames, expectedDistilleryName
+                => Assert.Contains(distilleryNameDetails!, actual => expectedDistilleryName == actual.DistilleryName)),
+            () => Assert.All(distilleryNameDetails!, distilleryNameDetail
+                => Assert.NotEqual(Guid.Empty, distilleryNameDetail.Identifier)));
+    }
+
+    [Fact]
+    public async Task When_SearchingByNameAndPatternIsNotProvided_Expect_BadRequestWithValidationProblemDetails()
+    {
+        const string endpoint = "/distilleries/name/search";
+
+        var expectedProblem = new ValidationProblemDetails
         {
-            var endpoint = $"/distilleries/name/search?pattern={pattern}";
-
-            var expectedProblem = new ValidationProblemDetails
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Missing or empty query parameters",
+            Type = "urn:mywhiskyshelf:validation-errors:query-parameter",
+            Errors = new Dictionary<string, string[]>
             {
-                Status = StatusCodes.Status400BadRequest,
-                Title = "Missing or empty query parameters",
-                Type = "urn:mywhiskyshelf:validation-errors:query-parameter",
-                Errors = new Dictionary<string, string[]>
-                {
-                    { "pattern", ["Query parameter 'pattern' is required and cannot be empty."] }
-                }
-            };
+                { "pattern", ["Query parameter 'pattern' is required and cannot be empty."] }
+            }
+        };
 
-            using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
-            var response = await httpClient.GetAsync(endpoint);
-            var problemResponse = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var response = await httpClient.GetAsync(endpoint);
+        var problemResponse = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
 
-            Assert.Multiple(
-                () => Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode),
-                () => Assert.Equivalent(expectedProblem, problemResponse));
-        }
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode),
+            () => Assert.Equivalent(expectedProblem, problemResponse));
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData("    ")]
+    [InlineData("\t \n")]
+    public async Task When_SearchingByNameAndPatternIsEmptyOrWhiteSpace_Expect_BadRequestProblemResponse(
+        string pattern)
+    {
+        var endpoint = $"/distilleries/name/search?pattern={pattern}";
+
+        var expectedProblem = new ValidationProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Missing or empty query parameters",
+            Type = "urn:mywhiskyshelf:validation-errors:query-parameter",
+            Errors = new Dictionary<string, string[]>
+            {
+                { "pattern", ["Query parameter 'pattern' is required and cannot be empty."] }
+            }
+        };
+
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var response = await httpClient.GetAsync(endpoint);
+        var problemResponse = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+
+        Assert.Multiple(
+            () => Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode),
+            () => Assert.Equivalent(expectedProblem, problemResponse));
     }
 }

--- a/MyWhiskyShelf.IntegrationTests/WebApi/WebApiWhiskyBottleTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/WebApi/WebApiWhiskyBottleTests.cs
@@ -8,7 +8,6 @@ namespace MyWhiskyShelf.IntegrationTests.WebApi;
 
 [Collection("AspireTests")]
 public class WebApiWhiskyBottleTests(MyWhiskyShelfFixture fixture)
-    : IClassFixture<MyWhiskyShelfFixture>
 {
     private const string WebApiResourceName = "WebApi";
 

--- a/MyWhiskyShelf.TestHelpers/Assertions.cs
+++ b/MyWhiskyShelf.TestHelpers/Assertions.cs
@@ -1,0 +1,11 @@
+using MyWhiskyShelf.Core.Models;
+
+namespace MyWhiskyShelf.TestHelpers;
+
+public static class Assertions
+{
+    public static bool EqualsIgnoringId(DistilleryResponse expected, DistilleryResponse actual)
+    {
+        return expected with { Id = Guid.Empty } == actual with { Id = Guid.Empty };
+    }
+}

--- a/MyWhiskyShelf.TestHelpers/DatabaseSeeding.cs
+++ b/MyWhiskyShelf.TestHelpers/DatabaseSeeding.cs
@@ -1,0 +1,28 @@
+using System.Net.Http.Json;
+using MyWhiskyShelf.Core.Models;
+
+namespace MyWhiskyShelf.TestHelpers;
+
+public static class DatabaseSeeding
+{
+    public static async Task<List<Guid>> AddDistilleries(HttpClient httpClient,
+        params DistilleryRequest[] distilleryRequests)
+    {
+        const string addEndpoint = "/distilleries";
+        var createdIds = new List<Guid>();
+        foreach (var distilleryRequest in distilleryRequests)
+        {
+            var response = await httpClient.PostAsJsonAsync(addEndpoint, distilleryRequest);
+            var identifierString = response.Headers.Location!.OriginalString.Split('/').Last();
+            createdIds.Add(Guid.Parse(identifierString));
+        }
+
+        return createdIds;
+    }
+
+    public static async Task RemoveDistilleries(HttpClient httpClient, List<Guid> ids)
+    {
+        foreach (var id in ids)
+            await httpClient.DeleteAsync($"/distilleries/{id}");
+    }
+}

--- a/MyWhiskyShelf.WebApi/Endpoints/WhiskyBottleEndpoints.cs
+++ b/MyWhiskyShelf.WebApi/Endpoints/WhiskyBottleEndpoints.cs
@@ -10,6 +10,7 @@ internal static partial class EndpointMappings
     private const string WhiskyBottleEndpoint = "/whisky-bottle";
     private const string GetByIdEndpoint = "/whisky-bottle/{identifier:guid}";
     private const string WhiskyBottleTag = "WhiskyBottle";
+
     public static void MapWhiskyBottleEndpoints(this WebApplication app)
     {
         app.MapGet(

--- a/MyWhiskyShelf.WebApi/ProblemResults/ProblemResults.cs
+++ b/MyWhiskyShelf.WebApi/ProblemResults/ProblemResults.cs
@@ -20,7 +20,7 @@ internal static class ProblemResults
     }
 
 
-    public static IResult DistilleryNotFound(string distilleryName, HttpContext httpContext)
+    public static IResult DistilleryNotFound(Guid distilleryId, HttpContext httpContext)
     {
         return Results.Problem(
             new ProblemDetails
@@ -28,7 +28,7 @@ internal static class ProblemResults
                 Type = "urn:mywhiskyshelf:errors:distillery-does-not-exist",
                 Title = "Distillery does not exist.",
                 Status = StatusCodes.Status404NotFound,
-                Detail = $"Cannot remove distillery '{distilleryName}' as it does not exist.",
+                Detail = $"Cannot remove distillery '{distilleryId}' as it does not exist.",
                 Instance = httpContext.Request.Path
             });
     }

--- a/MyWhiskyShelf.WebApi/Program.cs
+++ b/MyWhiskyShelf.WebApi/Program.cs
@@ -90,6 +90,7 @@ internal static class Program
 
             dbContext.Set<DistilleryEntity>().AddRange(mappedDistilleries);
         }
+
         await dbContext.SaveChangesAsync();
 
         var cacheService = scope.ServiceProvider.GetRequiredService<IDistilleryNameCacheService>();


### PR DESCRIPTION
The aim of this is to improve the speed of the integration tests by isolating each test with its own data seeding and cleanup, thereby allowing a single `DistributedApplication` to be shared.

* Rename `MyWhiskyShelfBaseFixture` to `MyWhiskyShelfFixture` and remove derived classes as no longer required and always disable data seeding.
* Update collection definition to be a collection fixture.
* Add TestHelper tools for database seeding and asserting.
* Update DistilleryName endpoints to use Ids.
* Update `TryAddDistillery` to return a tuple of success result and the entity identifier.
* Update tests to reflect identifier changes.
* Update `ProblemResults` to show id and not name.
* Various Whitespace fixes