### PR TITLE
Add delete whisky bottle from database functionality

### DIFF
--- a/MyWhiskyShelf.Database.Tests/TestHelpers/MyWhiskyShelfContextBuilder.cs
+++ b/MyWhiskyShelf.Database.Tests/TestHelpers/MyWhiskyShelfContextBuilder.cs
@@ -23,12 +23,21 @@ public static class MyWhiskyShelfContextBuilder
         return dbContext;
     }
 
-    public static MyWhiskyShelfDbContext CreateFailingDbContextAsync(Type exceptionType)
+    public static async Task<MyWhiskyShelfDbContext> CreateFailingDbContextAsync<TEntity>(
+        Type exceptionType, 
+        params TEntity[] whiskyBottleEntities) where TEntity : class
     {
         var options = new DbContextOptionsBuilder<MyWhiskyShelfDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
 
-        return new FailingSaveChangesDbContext(options, exceptionType);
+        var dbContext = new FailingSaveChangesDbContext(options, exceptionType);
+        
+        // This adds to the entity tracking but does not save to the database as this would cause an exception.
+        // This is sufficient as entities are retrieved using .Find() which checks the entity tracking first.
+        await dbContext.AddRangeAsync(whiskyBottleEntities.ToList());
+        
+        
+        return dbContext;
     }
 }

--- a/MyWhiskyShelf.Database/Contexts/MyWhiskyShelfDbContext.cs
+++ b/MyWhiskyShelf.Database/Contexts/MyWhiskyShelfDbContext.cs
@@ -9,6 +9,6 @@ namespace MyWhiskyShelf.Database.Contexts;
 public class MyWhiskyShelfDbContext(
     DbContextOptions<MyWhiskyShelfDbContext> options) : DbContext(options)
 {
-    public DbSet<DistilleryEntity> Distilleries { get; set; }
-    public DbSet<WhiskyBottleEntity> WhiskyBottles { get; set; }
+    internal DbSet<DistilleryEntity> Distilleries { get; set; }
+    internal DbSet<WhiskyBottleEntity> WhiskyBottles { get; set; }
 }

--- a/MyWhiskyShelf.Database/Services/WhiskyBottleWriteService.cs
+++ b/MyWhiskyShelf.Database/Services/WhiskyBottleWriteService.cs
@@ -17,12 +17,29 @@ public class WhiskyBottleWriteService(
         {
             dbContext.WhiskyBottles.Add(whiskyBottleEntity);
             await dbContext.SaveChangesAsync();
+            return (true, whiskyBottleEntity.Id);
         }
         catch
         {
             return (false, null);
         }
+    }
 
-        return (true, whiskyBottleEntity.Id);
+    public async Task<bool> TryDeleteAsync(Guid identifier)
+    {
+        var entity = await dbContext.WhiskyBottles.FindAsync(identifier);
+
+        if (entity is null) return false;
+
+        try
+        {
+            dbContext.WhiskyBottles.Remove(entity);
+            await dbContext.SaveChangesAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
* Update `WhiskyBottleWriteService` with delete functionality.
* Add unit tests and exception handling.
* Update `FailingDbContext` to allow an entity to be added to the change tracker.