### PR TITLE
Add whisky bottle update functionality to WebApi

### DIFF
--- a/MyWhiskyShelf.Database.Tests/Mappers/WhiskyBottleEntityToResponseMapperTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Mappers/WhiskyBottleEntityToResponseMapperTests.cs
@@ -21,9 +21,11 @@ public class WhiskyBottleEntityToResponseMapperTests
     [Fact]
     public void When_MapToDomainWithDateBottledButNotYearBottled_Expect_DomainModelWithYearBottledSetFromDate()
     {
+        var whiskyBottleEntity = WhiskyBottleEntityTestData.AllValuesPopulated;
+        whiskyBottleEntity.YearBottled = null;
         var whiskyBottleMapper = new WhiskyBottleEntityToResponseMapper();
         var whiskyBottle = whiskyBottleMapper
-            .Map(WhiskyBottleEntityTestData.AllValuesPopulated with { YearBottled = null });
+            .Map(whiskyBottleEntity);
 
         Assert.Equal(WhiskyBottleEntityTestData.AllValuesPopulated.DateBottled?.Year, whiskyBottle.YearBottled);
     }
@@ -31,11 +33,15 @@ public class WhiskyBottleEntityToResponseMapperTests
     [Fact]
     public void When_MapToDomainWithoutDateBottledOrYearBottled_Expect_DomainModelWithoutYearBottledSet()
     {
+        var whiskyBottleEntity = WhiskyBottleEntityTestData.AllValuesPopulated;
+        whiskyBottleEntity.YearBottled = null;
+        whiskyBottleEntity.DateBottled = null;
+            
         var whiskyBottleMapper = new WhiskyBottleEntityToResponseMapper();
-        var whiskyBottleEntity = whiskyBottleMapper
-            .Map(WhiskyBottleEntityTestData.AllValuesPopulated with { DateBottled = null, YearBottled = null });
+        var whiskyBottle = whiskyBottleMapper
+            .Map(whiskyBottleEntity);
 
-        Assert.Null(whiskyBottleEntity.YearBottled);
+        Assert.Null(whiskyBottle.YearBottled);
     }
 
     [Theory]
@@ -47,9 +53,11 @@ public class WhiskyBottleEntityToResponseMapperTests
         string status,
         BottleStatus expectedStatus)
     {
+        var whiskyBottleEntity = WhiskyBottleEntityTestData.AllValuesPopulated;
+        whiskyBottleEntity.Status = status;
+        
         var whiskyBottleMapper = new WhiskyBottleEntityToResponseMapper();
-        var whiskyBottle = whiskyBottleMapper
-            .Map(WhiskyBottleEntityTestData.AllValuesPopulated with { Status = status });
+        var whiskyBottle = whiskyBottleMapper.Map(whiskyBottleEntity);
 
         Assert.Equal(expectedStatus.ToString(), whiskyBottle.Status);
     }

--- a/MyWhiskyShelf.Database.Tests/Mappers/WhiskyBottleRequestToEntityMapperTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Mappers/WhiskyBottleRequestToEntityMapperTests.cs
@@ -15,11 +15,14 @@ public class WhiskyBottleRequestToEntityMapperTests
     [Fact]
     public void When_MapToEntityWithAllValuesPopulated_Expect_EntityWithAllValuesPopulated()
     {
+        var expectedWhiskyBottleEntity = WhiskyBottleEntityTestData.AllValuesPopulated;
+        expectedWhiskyBottleEntity.Id = Guid.Empty;
+        
         var whiskyBottleMapper = new WhiskyBottleRequestToEntityMapper(_mockDistilleryNameCacheService.Object);
 
         var whiskyBottleEntity = whiskyBottleMapper.Map(WhiskyBottleRequestTestData.AllValuesPopulated);
 
-        Assert.Equal(WhiskyBottleEntityTestData.AllValuesPopulated with { Id = Guid.Empty }, whiskyBottleEntity);
+        Assert.Equivalent(expectedWhiskyBottleEntity, whiskyBottleEntity);
     }
 
     [Fact]

--- a/MyWhiskyShelf.Database.Tests/Services/WhiskyBottleReadServiceTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Services/WhiskyBottleReadServiceTests.cs
@@ -20,7 +20,7 @@ public class WhiskyBottleReadServiceTests
         var mockRequestToEntityMapper = new Mock<IMapper<WhiskyBottleEntity, WhiskyBottleResponse>>();
 
         mockRequestToEntityMapper
-            .Setup(mapper => mapper.Map(WhiskyBottleEntityTestData.AllValuesPopulated))
+            .Setup(mapper => mapper.Map(It.IsAny<WhiskyBottleEntity>()))
             .Returns(WhiskyBottleResponseTestData.AllValuesPopulated)
             .Verifiable(Times.Once);
 
@@ -28,7 +28,7 @@ public class WhiskyBottleReadServiceTests
         var whiskyBottle = await whiskyBottleReadService.GetByIdAsync(WhiskyBottleEntityTestData.AllValuesPopulated.Id);
 
         Assert.Multiple(
-            () => Assert.Equal(WhiskyBottleResponseTestData.AllValuesPopulated, whiskyBottle),
+            () => Assert.Equivalent(WhiskyBottleResponseTestData.AllValuesPopulated, whiskyBottle),
             () => mockRequestToEntityMapper.Verify());
     }
 

--- a/MyWhiskyShelf.Database.Tests/Services/WhiskyBottleWriteServiceTests.cs
+++ b/MyWhiskyShelf.Database.Tests/Services/WhiskyBottleWriteServiceTests.cs
@@ -119,4 +119,75 @@ public class WhiskyBottleWriteServiceTests
 
         Assert.False(hasBeenDeleted);
     }
+
+    [Fact]
+    public async Task When_UpdateWhiskyBottleAndWhiskyBottleExists_Expect_ReturnsTrueAndBottleUpdated()
+    {
+        var mappedWhiskyBottleEntity = WhiskyBottleEntityTestData.AllValuesPopulated;
+        mappedWhiskyBottleEntity.VolumeRemainingCl = 20;
+
+        await using var dbContext = await MyWhiskyShelfContextBuilder.CreateDbContextAsync(
+            WhiskyBottleEntityTestData.AllValuesPopulated);
+        var updatedWhiskyBottle = WhiskyBottleRequestTestData.AllValuesPopulated with { VolumeRemainingCl = 20 };
+        var mockWhiskyBottleMapper = new Mock<IMapper<WhiskyBottleRequest, WhiskyBottleEntity>>();
+        mockWhiskyBottleMapper
+            .Setup(mapper => mapper.Map(updatedWhiskyBottle))
+            .Returns(mappedWhiskyBottleEntity);
+
+        var whiskyBottleService = new WhiskyBottleWriteService(dbContext, mockWhiskyBottleMapper.Object);
+        var hasBeenUpdated = await whiskyBottleService.TryUpdateAsync(
+            WhiskyBottleEntityTestData.AllValuesPopulated.Id,
+            updatedWhiskyBottle);
+        var whiskyBottleEntity = await dbContext
+            .Set<WhiskyBottleEntity>()
+            .FindAsync(WhiskyBottleEntityTestData.AllValuesPopulated.Id);
+
+        Assert.Multiple(
+            () => Assert.Equal(20, whiskyBottleEntity!.VolumeRemainingCl),
+            () => Assert.True(hasBeenUpdated));
+    }
+    
+   [Fact]
+    public async Task When_UpdateWhiskyBottleAndWhiskyBottleDoesNotExist_Expect_ReturnsFalse()
+    {
+        await using var dbContext = await MyWhiskyShelfContextBuilder.CreateDbContextAsync<WhiskyBottleEntity>();
+        
+        var mockWhiskyBottleMapper = new Mock<IMapper<WhiskyBottleRequest, WhiskyBottleEntity>>();
+        mockWhiskyBottleMapper
+            .Setup(mapper => mapper.Map(WhiskyBottleRequestTestData.AllValuesPopulated))
+            .Returns(WhiskyBottleEntityTestData.AllValuesPopulated);
+        
+        var whiskyBottleService = new WhiskyBottleWriteService(dbContext, mockWhiskyBottleMapper.Object);
+        var hasBeenUpdated = await whiskyBottleService.TryUpdateAsync(
+            WhiskyBottleEntityTestData.AllValuesPopulated.Id,
+            WhiskyBottleRequestTestData.AllValuesPopulated);
+        
+        Assert.False(hasBeenUpdated);
+    }
+    
+    [Theory]
+    [InlineData(typeof(DbUpdateException))]
+    [InlineData(typeof(DbUpdateConcurrencyException))]
+    [InlineData(typeof(Exception))]
+    public async Task When_UpdateWhiskyBottleAndDatabaseThrowsException_Expect_ReturnsFalse(Type exceptionType)
+    {
+        var mappedWhiskyBottleEntity = WhiskyBottleEntityTestData.AllValuesPopulated;
+        mappedWhiskyBottleEntity.VolumeRemainingCl = 20;
+        
+        await using var dbContext = await MyWhiskyShelfContextBuilder
+            .CreateFailingDbContextAsync(exceptionType, WhiskyBottleEntityTestData.AllValuesPopulated);
+
+        var updatedWhiskyBottle = WhiskyBottleRequestTestData.AllValuesPopulated with { VolumeRemainingCl = 20 };
+        var mockWhiskyBottleMapper = new Mock<IMapper<WhiskyBottleRequest, WhiskyBottleEntity>>();
+        mockWhiskyBottleMapper
+            .Setup(mapper => mapper.Map(updatedWhiskyBottle))
+            .Returns(mappedWhiskyBottleEntity);
+
+        var whiskyBottleService = new WhiskyBottleWriteService(dbContext, mockWhiskyBottleMapper.Object);
+        var hasBeenUpdated = await whiskyBottleService.TryUpdateAsync(
+            WhiskyBottleEntityTestData.AllValuesPopulated.Id,
+            updatedWhiskyBottle);
+
+        Assert.False(hasBeenUpdated);
+    }
 }

--- a/MyWhiskyShelf.Database/Configurations/WhiskyBottleEntityConfiguration.cs
+++ b/MyWhiskyShelf.Database/Configurations/WhiskyBottleEntityConfiguration.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MyWhiskyShelf.Database.Entities;
+
+namespace MyWhiskyShelf.Database.Configurations;
+
+public class WhiskyBottleEntityConfiguration : IEntityTypeConfiguration<WhiskyBottleEntity>
+{
+    public void Configure(EntityTypeBuilder<WhiskyBottleEntity> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.Name)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(e => e.DistilleryName)
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(e => e.Status)
+            .HasMaxLength(15)
+            .IsRequired();
+
+        builder.Property(e => e.Bottler)
+            .HasMaxLength(50);
+
+        builder.Property(e => e.DateBottled);
+        builder.Property(e => e.YearBottled);
+        builder.Property(e => e.BatchNumber);
+        builder.Property(e => e.CaskNumber);
+
+        builder.Property(e => e.AbvPercentage)
+            .HasPrecision(4, 1)
+            .IsRequired();
+
+        builder.Property(e => e.VolumeCl)
+            .IsRequired();
+
+        builder.Property(e => e.VolumeRemainingCl)
+            .IsRequired();
+
+        builder.Property(e => e.AddedColouring);
+        builder.Property(e => e.ChillFiltered);
+
+        builder.Property(e => e.EncodedFlavourProfile)
+            .IsRequired();
+
+        builder.HasIndex(e => e.DistilleryName)
+            .IsUnique(false);
+
+        builder.HasIndex(e => e.Status)
+            .IsUnique(false);
+    }
+}

--- a/MyWhiskyShelf.Database/Contexts/MyWhiskyShelfDbContext.cs
+++ b/MyWhiskyShelf.Database/Contexts/MyWhiskyShelfDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using MyWhiskyShelf.Database.Configurations;
 using MyWhiskyShelf.Database.Entities;
 
 namespace MyWhiskyShelf.Database.Contexts;
@@ -11,4 +12,10 @@ public class MyWhiskyShelfDbContext(
 {
     internal DbSet<DistilleryEntity> Distilleries { get; set; }
     internal DbSet<WhiskyBottleEntity> WhiskyBottles { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfiguration(new WhiskyBottleEntityConfiguration());
+    }
 }

--- a/MyWhiskyShelf.Database/Entities/WhiskyBottleEntity.cs
+++ b/MyWhiskyShelf.Database/Entities/WhiskyBottleEntity.cs
@@ -1,32 +1,24 @@
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+// EF Models should be classes and should have publicly settable properties
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
 
 namespace MyWhiskyShelf.Database.Entities;
 
-[Index(nameof(DistilleryName), IsUnique = false)]
-[Index(nameof(Status), IsUnique = false)]
-public record WhiskyBottleEntity
+public class WhiskyBottleEntity
 {
-    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-    public Guid Id { get; init; }
-
-    public required string Name { get; init; }
-    public required string DistilleryName { get; init; }
-    public Guid? DistilleryId { get; init; }
-    public required string Status { get; init; }
-    public string? Bottler { get; init; }
-    public DateOnly? DateBottled { get; init; }
-    public int? YearBottled { get; init; }
-    public int? BatchNumber { get; init; }
-    public int? CaskNumber { get; init; }
-
-    [Precision(4, 1)] public required decimal AbvPercentage { get; init; }
-
-    public required int VolumeCl { get; init; }
-    public required int VolumeRemainingCl { get; init; }
-
-    public bool? AddedColouring { get; init; }
-    public bool? ChillFiltered { get; init; }
-
-    public required ulong EncodedFlavourProfile { get; init; }
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required string DistilleryName { get; set; }
+    public Guid? DistilleryId { get; set; }
+    public required string Status { get; set; }
+    public string? Bottler { get; set; }
+    public DateOnly? DateBottled { get; set; }
+    public int? YearBottled { get; set; }
+    public int? BatchNumber { get; set; }
+    public int? CaskNumber { get; set; }
+    public required decimal AbvPercentage { get; set; }
+    public required int VolumeCl { get; set; }
+    public required int VolumeRemainingCl { get; set; }
+    public bool? AddedColouring { get; set; }
+    public bool? ChillFiltered { get; set; }
+    public required ulong EncodedFlavourProfile { get; set; }
 }

--- a/MyWhiskyShelf.Database/Interfaces/IWhiskyBottleWriteService.cs
+++ b/MyWhiskyShelf.Database/Interfaces/IWhiskyBottleWriteService.cs
@@ -5,5 +5,6 @@ namespace MyWhiskyShelf.Database.Interfaces;
 public interface IWhiskyBottleWriteService
 {
     Task<(bool hasBeenAdded, Guid? identifier)> TryAddAsync(WhiskyBottleRequest whiskyBottleRequest);
+    Task<bool> TryUpdateAsync(Guid identifier, WhiskyBottleRequest whiskyBottleRequest);
     Task<bool> TryDeleteAsync(Guid identifier);
 }

--- a/MyWhiskyShelf.Database/Services/WhiskyBottleReadService.cs
+++ b/MyWhiskyShelf.Database/Services/WhiskyBottleReadService.cs
@@ -12,7 +12,7 @@ public class WhiskyBottleReadService(
     public async Task<WhiskyBottleResponse?> GetByIdAsync(Guid distilleryId)
     {
         var whiskyBottle = await dbContext.WhiskyBottles.FindAsync(distilleryId);
-
+        
         return whiskyBottle is null
             ? null
             : mapper.Map(whiskyBottle);

--- a/MyWhiskyShelf.Database/Services/WhiskyBottleWriteService.cs
+++ b/MyWhiskyShelf.Database/Services/WhiskyBottleWriteService.cs
@@ -9,7 +9,7 @@ public class WhiskyBottleWriteService(
     MyWhiskyShelfDbContext dbContext,
     IMapper<WhiskyBottleRequest, WhiskyBottleEntity> mapper) : IWhiskyBottleWriteService
 {
-    public async Task<(bool hasBeenAdded, Guid? identifier)> TryAddAsync(WhiskyBottleRequest whiskyBottleRequest)
+   public async Task<(bool hasBeenAdded, Guid? identifier)> TryAddAsync(WhiskyBottleRequest whiskyBottleRequest)
     {
         var whiskyBottleEntity = mapper.Map(whiskyBottleRequest);
 
@@ -34,6 +34,26 @@ public class WhiskyBottleWriteService(
         try
         {
             dbContext.WhiskyBottles.Remove(entity);
+            await dbContext.SaveChangesAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> TryUpdateAsync(Guid identifier, WhiskyBottleRequest whiskyBottleRequest)
+    {
+        var existingEntity = await dbContext.WhiskyBottles.FindAsync(identifier);
+        if (existingEntity is null) return false;
+        
+        var updatedEntity = mapper.Map(whiskyBottleRequest);
+        updatedEntity.Id = existingEntity.Id;
+        
+        try
+        {
+            dbContext.Entry(existingEntity).CurrentValues.SetValues(updatedEntity);
             await dbContext.SaveChangesAsync();
             return true;
         }

--- a/MyWhiskyShelf.IntegrationTests/WebApi/WebApiWhiskyBottleTests.cs
+++ b/MyWhiskyShelf.IntegrationTests/WebApi/WebApiWhiskyBottleTests.cs
@@ -92,6 +92,21 @@ public class WebApiWhiskyBottleTests(MyWhiskyShelfFixture fixture)
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    [Fact]
+    public async Task When_UpdateWhiskyBottleAndWhiskyBottleIsFound_Expect_OkResponse()
+    {
+        using var httpClient = fixture.Application.CreateHttpClient(WebApiResourceName);
+        var createResponse = await httpClient.PostAsJsonAsync(
+            "/whisky-bottle", 
+            WhiskyBottleRequestTestData.AllValuesPopulated);
+        
+        var response = await httpClient.PutAsJsonAsync(
+            createResponse.Headers.Location,
+            WhiskyBottleRequestTestData.AllValuesPopulated with { VolumeRemainingCl = 20 });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+    
     private static void AssertIsGuidAndNotEmpty(string guidString)
     {
         if (!Guid.TryParse(guidString, out var result))

--- a/MyWhiskyShelf.WebApi/Endpoints/WhiskyBottleEndpoints.cs
+++ b/MyWhiskyShelf.WebApi/Endpoints/WhiskyBottleEndpoints.cs
@@ -47,6 +47,25 @@ internal static partial class EndpointMappings
             .Produces(StatusCodes.Status201Created)
             .ProducesValidationProblem();
 
+        app.MapPut(
+            WhiskyBottleWithRouteIdentifierEndpoint,
+            async (
+                [FromServices] IWhiskyBottleWriteService whiskyBottleWriteService,
+                [FromRoute] Guid identifier,
+                [FromBody] WhiskyBottleRequest whiskyBottleRequest,
+                HttpContext httpContext) =>
+            {
+                var hasBeenUpdated = await whiskyBottleWriteService.TryUpdateAsync(identifier, whiskyBottleRequest);
+
+                return hasBeenUpdated
+                    ? Results.Ok()
+                    : ProblemResults.ResourceNotFound("whisky-bottle", identifier, httpContext);
+            })
+            .WithName("Update Whisky Bottle")
+            .WithTags(WhiskyBottleTag)
+            .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+        
         app.MapDelete(
             WhiskyBottleWithRouteIdentifierEndpoint,
             async (


### PR DESCRIPTION
* Add whisky bottle update functionality to WebApi.
* Add integration tests for whisky bottle update functionality.
* Update WhiskyBottle model to a class as records can cause issues for entities in EF.
* Move model creation to context to avoid polluting the model with attribute tags.
* Add configuration method for WhiskyBottle to keep each model creation separate.
* Update tests to use the new classes there for 'with { Property = Value }' style cannot be used.