### PR TITLE
Add code coverage exclusions

### DIFF
--- a/MyWhiskyShelf.Infrastructure/Persistence/Repositories/DistilleryReadRepository.cs
+++ b/MyWhiskyShelf.Infrastructure/Persistence/Repositories/DistilleryReadRepository.cs
@@ -7,6 +7,9 @@ using MyWhiskyShelf.Infrastructure.Persistence.Contexts;
 
 namespace MyWhiskyShelf.Infrastructure.Persistence.Repositories;
 
+// Repository level tests are covered by integration tests, and specific functionality, such as postgres functions
+// cannot be tested against sqlite / in-memory db.
+[ExcludeFromCodeCoverage]
 public sealed class DistilleryReadRepository(MyWhiskyShelfDbContext dbContext) : IDistilleryReadRepository
 {
     public async Task<Distillery?> GetByIdAsync(Guid id, CancellationToken ct = default)

--- a/MyWhiskyShelf.Infrastructure/Persistence/Repositories/DistilleryWriteRepository.cs
+++ b/MyWhiskyShelf.Infrastructure/Persistence/Repositories/DistilleryWriteRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using MyWhiskyShelf.Application.Abstractions.Repositories;
 using MyWhiskyShelf.Core.Aggregates;
 using MyWhiskyShelf.Infrastructure.Mapping;
@@ -5,6 +6,9 @@ using MyWhiskyShelf.Infrastructure.Persistence.Contexts;
 
 namespace MyWhiskyShelf.Infrastructure.Persistence.Repositories;
 
+// Repository level tests are covered by integration tests, and specific functionality, such as postgres functions
+// cannot be tested against sqlite / in-memory db.
+[ExcludeFromCodeCoverage]
 public sealed class DistilleryWriteRepository(MyWhiskyShelfDbContext dbContext) : IDistilleryWriteRepository
 {
     public async Task<Distillery?> AddAsync(Distillery distillery, CancellationToken ct = default)

--- a/MyWhiskyShelf.Infrastructure/Persistence/Repositories/WhiskyBottleReadRepository.cs
+++ b/MyWhiskyShelf.Infrastructure/Persistence/Repositories/WhiskyBottleReadRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using MyWhiskyShelf.Application.Abstractions.Repositories;
 using MyWhiskyShelf.Core.Aggregates;
 using MyWhiskyShelf.Infrastructure.Mapping;
@@ -5,6 +6,9 @@ using MyWhiskyShelf.Infrastructure.Persistence.Contexts;
 
 namespace MyWhiskyShelf.Infrastructure.Persistence.Repositories;
 
+// Repository level tests are covered by integration tests, and specific functionality, such as postgres functions
+// cannot be tested against sqlite / in-memory db.
+[ExcludeFromCodeCoverage]
 public sealed class WhiskyBottleReadRepository(MyWhiskyShelfDbContext dbContext) : IWhiskyBottleReadRepository
 {
     public async Task<WhiskyBottle?> GetByIdAsync(Guid id, CancellationToken ct = default)

--- a/MyWhiskyShelf.Infrastructure/Persistence/Repositories/WhiskyBottleWriteRepository.cs
+++ b/MyWhiskyShelf.Infrastructure/Persistence/Repositories/WhiskyBottleWriteRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using MyWhiskyShelf.Application.Abstractions.Repositories;
 using MyWhiskyShelf.Core.Aggregates;
 using MyWhiskyShelf.Infrastructure.Mapping;
@@ -5,6 +6,9 @@ using MyWhiskyShelf.Infrastructure.Persistence.Contexts;
 
 namespace MyWhiskyShelf.Infrastructure.Persistence.Repositories;
 
+// Repository level tests are covered by integration tests, and specific functionality, such as postgres functions
+// cannot be tested against sqlite / in-memory db.
+[ExcludeFromCodeCoverage]
 public sealed class WhiskyBottleWriteRepository(MyWhiskyShelfDbContext dbContext) : IWhiskyBottleWriteRepository
 {
     public async Task<WhiskyBottle> AddAsync(WhiskyBottle whiskyBottle, CancellationToken ct = default)

--- a/MyWhiskyShelf.WebApi/Endpoints/DistilleryEndpoints.cs
+++ b/MyWhiskyShelf.WebApi/Endpoints/DistilleryEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using MyWhiskyShelf.Application.Abstractions.Services;
@@ -9,6 +10,8 @@ using MyWhiskyShelf.WebApi.Mapping;
 
 namespace MyWhiskyShelf.WebApi.Endpoints;
 
+// Endpoints are covered by integration tests which are managed by Aspire, and do not need to be tested independently
+[ExcludeFromCodeCoverage]
 public static class DistilleryEndpoints
 {
     public static void MapDistilleryEndpoints(this IEndpointRouteBuilder app)

--- a/MyWhiskyShelf.WebApi/Endpoints/WhiskyBottleEndpoints.cs
+++ b/MyWhiskyShelf.WebApi/Endpoints/WhiskyBottleEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using MyWhiskyShelf.Application.Abstractions.Services;
@@ -9,6 +10,8 @@ using MyWhiskyShelf.WebApi.Mapping;
 
 namespace MyWhiskyShelf.WebApi.Endpoints;
 
+// Endpoints are covered by integration tests which are managed by Aspire, and do not need to be tested independently
+[ExcludeFromCodeCoverage]
 public static class WhiskyBottleEndpoints
 {
     public static void MapWhiskyBottleEndpoints(this IEndpointRouteBuilder app)


### PR DESCRIPTION
* Add code coverage exclusions for repository and endpoints as they are covered by integration tests, which run in the Aspire environment